### PR TITLE
feat: diagonal bridger & configurations

### DIFF
--- a/src/main/java/io/github/waqfs/agent/BedwarsAgent.java
+++ b/src/main/java/io/github/waqfs/agent/BedwarsAgent.java
@@ -100,7 +100,7 @@ public class BedwarsAgent extends BaseAgent {
         return isBlock(blockItem.getBlock().getDefaultState());
     }
 
-    public static boolean switchToTheNextStackOfWoolOrClayOrEndStoneOrWoodOrObsidianOrGlassOrAnyOtherPlaceableBlockThatIsNotALadderOrTNTBecauseThatIsNotARealBlockInTheHotOfTheBarImmediatelyOnTheSubsequentTick(ClientPlayerEntity player) {
+    public static boolean switchToNextStackOfBlocks(ClientPlayerEntity player) {
         for (int i = 0; i < 9; i++) {
             if (isBlock(player.getInventory().getStack(i))) {
                 player.getInventory().setSelectedSlot(i);

--- a/src/main/java/io/github/waqfs/module/bedwars/Bridger.java
+++ b/src/main/java/io/github/waqfs/module/bedwars/Bridger.java
@@ -113,7 +113,7 @@ public class Bridger extends TickModule<ToggleWidget, Boolean> {
     private void cycleIfNoBlocks(ClientPlayerEntity player) {
         if (!blockSwap.getRawState()) return;
         if (!BedwarsAgent.isBlock(player.getMainHandStack())) {
-            boolean hasMoreBlocks = BedwarsAgent.switchToTheNextStackOfWoolOrClayOrEndStoneOrWoodOrObsidianOrGlassOrAnyOtherPlaceableBlockThatIsNotALadderOrTNTBecauseThatIsNotARealBlockInTheHotOfTheBarImmediatelyOnTheSubsequentTick(player);
+            boolean hasMoreBlocks = BedwarsAgent.switchToNextStackOfBlocks(player);
             if (!hasMoreBlocks) {
                 disable();
             }


### PR DESCRIPTION
- **feat: diagonal bridger**
- **start bridgers only if holding blocks**
- **require block to be +1 on the x/z axis to start bridger**
- **require placing on the block below the player to start bridger & god mode detection**
- **increase block range to entire 3x3 below the player**
- **merge diagonal bridger with straight bridger**
- **add configuration to the bridgers**
- **fix: straight bridger staying active if left/right key is released**
- **add toggle for automatic block swapping**
