### PR TITLE
fix: zombies aimbot attempting to shoot through invalid blocks

### DIFF
--- a/src/main/java/dev/cigarette/agent/ZombiesAgent.java
+++ b/src/main/java/dev/cigarette/agent/ZombiesAgent.java
@@ -1,5 +1,6 @@
 package dev.cigarette.agent;
 
+import dev.cigarette.Cigarette;
 import dev.cigarette.GameDetector;
 import dev.cigarette.gui.widget.ToggleWidget;
 import dev.cigarette.lib.Raycast;
@@ -25,8 +26,7 @@ import net.minecraft.util.math.Vec3d;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.HashSet;
-import java.util.UUID;
+import java.util.*;
 
 public class ZombiesAgent extends BaseAgent {
     private static final HashSet<ZombieTarget> zombies = new HashSet<>();
@@ -43,6 +43,140 @@ public class ZombiesAgent extends BaseAgent {
         }
         return state.isOf(Blocks.IRON_BARS) || state.isOf(Blocks.BARRIER) || state.isOf(Blocks.CHEST) || state.isIn(BlockTags.SIGNS);
     }
+
+//    ==============================
+//    Syfe Aimbot
+
+    private final Map<UUID, Vec3d> lastPositions = new HashMap<>();
+    private final Map<UUID, Vec3d> velocities = new HashMap<>();
+
+    @Nullable
+    private ZombiesAgent.ZombieTarget getBestTarget(ClientPlayerEntity player) {
+        HashSet<ZombiesAgent.ZombieTarget> zombies = ZombiesAgent.getZombies();
+        if (zombies.isEmpty()) {
+            return null;
+        }
+
+        ZombiesAgent.ZombieTarget bestTarget = null;
+        double minTimeToPlayer = Double.MAX_VALUE;
+
+        Vec3d playerPos = player.getPos();
+
+        for (ZombiesAgent.ZombieTarget zombie : zombies) {
+            Vec3d zombiePos = zombie.entity.getPos();
+            double distance = playerPos.distanceTo(zombiePos);
+
+            Vec3d velocity = velocities.getOrDefault(zombie.uuid, Vec3d.ZERO);
+            Vec3d playerToZombie = zombiePos.subtract(playerPos).normalize();
+            double speedTowardsPlayer = -velocity.dotProduct(playerToZombie) * 20;
+
+            if (speedTowardsPlayer <= 0.1) {
+                // Use distance as a fallback metric for stationary or retreating targets
+                if (bestTarget == null || distance < playerPos.distanceTo(bestTarget.entity.getPos())) {
+                    bestTarget = zombie;
+                }
+                continue;
+            }
+
+            double timeToPlayer = distance / speedTowardsPlayer;
+
+            if (timeToPlayer < minTimeToPlayer) {
+                minTimeToPlayer = timeToPlayer;
+                bestTarget = zombie;
+            }
+        }
+
+        return bestTarget;
+    }
+
+    private Vec3d calculatePredictedPosition(ZombiesAgent.ZombieTarget zombie, ClientPlayerEntity player) {
+        if (!Cigarette.CONFIG.ZOMBIES_AIMBOT.getRawState()) {
+            return zombie.getEndVec();
+        }
+
+        Vec3d currentPos = zombie.entity.getPos();
+        Vec3d playerPos = player.getEyePos();
+        Vec3d currentVelocity = velocities.getOrDefault(zombie.uuid, Vec3d.ZERO);
+        Vec3d pathDirection = getPathfindingDirection(zombie, currentPos, playerPos, currentVelocity);
+
+        if (pathDirection.lengthSquared() < 1.0E-7D) {
+            return zombie.getEndVec();
+        }
+
+        double distance = playerPos.distanceTo(currentPos);
+        double projectileSpeed = 20.0;
+        double timeToTarget = (projectileSpeed > 0) ? distance / projectileSpeed : 0;
+
+        int maxPredictionTicks = Cigarette.CONFIG.ZOMBIES_AIMBOT.predictionTicks.getRawState().intValue();
+        double maxPredictionTime = maxPredictionTicks / 20.0;
+        timeToTarget = Math.min(timeToTarget, maxPredictionTime);
+
+        Vec3d predictedBodyPos = currentPos.add(pathDirection.multiply(timeToTarget));
+
+        return predictedBodyPos.add(0, zombie.entity.getEyeHeight(zombie.entity.getPose()), 0);
+    }
+
+    private Vec3d getPathfindingDirection(ZombiesAgent.ZombieTarget zombie, Vec3d zombiePos, Vec3d playerPos, Vec3d currentVelocity) {
+        Vec3d directPath = playerPos.subtract(zombiePos).normalize();
+
+        if (currentVelocity.lengthSquared() > 1.0E-7D) {
+            Vec3d normalizedVelocity = currentVelocity.normalize();
+            double directness = normalizedVelocity.dotProduct(directPath);
+            directness = Math.max(0, Math.min(1, directness));
+
+            return directPath.multiply(1.0 - directness).add(normalizedVelocity.multiply(directness)).normalize().multiply(currentVelocity.length());
+        }
+
+        return directPath.multiply(estimateZombieSpeed(zombie) / 20.0);
+    }
+
+    private double estimateZombieSpeed(ZombiesAgent.ZombieTarget zombie) {
+        return switch (zombie.type) {
+            case ZOMBIE, SKELETON, CREEPER, WITCH -> 5.0; // ~0.25 B/t * 20 t/s
+            case BLAZE -> 8.0;
+            case WOLF -> 7.0;
+            case MAGMACUBE, SLIME -> 4.0;
+            case ENDERMITE, SILVERFISH -> 6.0;
+            default -> 5.0;
+        };
+    }
+
+    private void updateAllZombieVelocities() {
+        HashSet<ZombiesAgent.ZombieTarget> zombies = ZombiesAgent.getZombies();
+        if (zombies.isEmpty()) {
+            velocities.clear();
+            return;
+        }
+
+        for (ZombiesAgent.ZombieTarget zombie : zombies) {
+            UUID zombieId = zombie.uuid;
+            Vec3d currentPos = zombie.entity.getPos();
+            Vec3d lastPos = lastPositions.get(zombieId);
+
+            if (lastPos != null) {
+                velocities.put(zombieId, currentPos.subtract(lastPos));
+            }
+            lastPositions.put(zombieId, currentPos);
+        }
+    }
+
+    private void cleanupTrackingData() {
+        Set<UUID> currentZombies = new HashSet<>();
+        for (ZombiesAgent.ZombieTarget zombie : ZombiesAgent.getZombies()) {
+            currentZombies.add(zombie.uuid);
+        }
+
+        lastPositions.keySet().retainAll(currentZombies);
+        velocities.keySet().retainAll(currentZombies);
+    }
+
+
+    private void onDisabledTick() {
+        lastPositions.clear();
+        velocities.clear();
+    }
+
+//    ==============================
 
     public static HashSet<ZombieTarget> getZombies() {
         HashSet<ZombieTarget> alive = new HashSet<>();
@@ -129,6 +263,7 @@ public class ZombiesAgent extends BaseAgent {
     protected void onInvalidTick(MinecraftClient client) {
         zombies.clear();
         powerups.clear();
+        onDisabledTick(); // Syfe Aimbot
     }
 
     @Override

--- a/src/main/java/dev/cigarette/agent/ZombiesAgent.java
+++ b/src/main/java/dev/cigarette/agent/ZombiesAgent.java
@@ -92,8 +92,8 @@ public class ZombiesAgent extends BaseAgent {
     }
 
     private Vec3d calculatePredictedPosition(ZombiesAgent.ZombieTarget zombie, ClientPlayerEntity player) {
-        if (!Cigarette.CONFIG.ZOMBIES_AIMBOT.getRawState()) {
-            return zombie.getEndVec();
+        if (!Cigarette.CONFIG.ZOMBIES_AIMBOT.predictiveAim.getRawState()) {
+            return zombie.entity.getPos().subtract(player.getPos().add(0, player.getEyeHeight(EntityPose.STANDING), 0));
         }
 
         Vec3d currentPos = zombie.entity.getPos();
@@ -249,10 +249,9 @@ public class ZombiesAgent extends BaseAgent {
             Vec3d start = player.getPos().add(0, player.getEyeHeight(EntityPose.STANDING), 0);
 
             Vec3d predictedPos = calculatePredictedPosition(target, player);
-            Vec3d vector = predictedPos.subtract(player.getEyePos());
-            target.end = vector;
+            target.end = predictedPos;
 
-            Raycast.FirstBlock result = Raycast.firstBlockCollision(start, vector, this::isNoClipBlock);
+            Raycast.FirstBlock result = Raycast.firstBlockCollision(start, predictedPos, this::isNoClipBlock);
             if ((result.hit() && result.whitelisted()) || result.missed()) {
                 target.canShoot = true;
                 target.canHeadshot = true;
@@ -260,6 +259,8 @@ public class ZombiesAgent extends BaseAgent {
                 target.canShoot = false;
                 target.canHeadshot = false;
             }
+
+            System.out.println("zombie canShoot=" + target.canShoot);
         }
         cleanupTrackingData();
     }

--- a/src/main/java/dev/cigarette/agent/ZombiesAgent.java
+++ b/src/main/java/dev/cigarette/agent/ZombiesAgent.java
@@ -47,11 +47,11 @@ public class ZombiesAgent extends BaseAgent {
 //    ==============================
 //    Syfe Aimbot
 
-    private final Map<UUID, Vec3d> lastPositions = new HashMap<>();
-    private final Map<UUID, Vec3d> velocities = new HashMap<>();
+    private static final Map<UUID, Vec3d> lastPositions = new HashMap<>();
+    private static final Map<UUID, Vec3d> velocities = new HashMap<>();
 
     @Nullable
-    private ZombiesAgent.ZombieTarget getBestTarget(ClientPlayerEntity player) {
+    public static ZombiesAgent.ZombieTarget getBestTarget(ClientPlayerEntity player) {
         HashSet<ZombiesAgent.ZombieTarget> zombies = ZombiesAgent.getZombies();
         if (zombies.isEmpty()) {
             return null;
@@ -63,6 +63,8 @@ public class ZombiesAgent extends BaseAgent {
         Vec3d playerPos = player.getPos();
 
         for (ZombiesAgent.ZombieTarget zombie : zombies) {
+            if (!zombie.canShoot) continue;
+
             Vec3d zombiePos = zombie.entity.getPos();
             double distance = playerPos.distanceTo(zombiePos);
 

--- a/src/main/java/dev/cigarette/agent/ZombiesAgent.java
+++ b/src/main/java/dev/cigarette/agent/ZombiesAgent.java
@@ -75,7 +75,7 @@ public class ZombiesAgent extends BaseAgent {
 
     public static boolean isGun(ItemStack item) {
         if (item.isOf(Items.IRON_SWORD)) return false;
-        return item.isIn(ItemTags.WEAPON_ENCHANTABLE) || item.isIn(ItemTags.HOES) || item.isIn(ItemTags.SHOVELS) || item.isIn(ItemTags.AXES) || item.isIn(ItemTags.PICKAXES) || item.isOf(Items.SHEARS);
+        return item.isIn(ItemTags.WEAPON_ENCHANTABLE) || item.isIn(ItemTags.HOES) || item.isIn(ItemTags.SHOVELS) || item.isIn(ItemTags.AXES) || item.isIn(ItemTags.PICKAXES) || item.isOf(Items.SHEARS) || item.isOf(Items.FLINT_AND_STEEL);
     }
 
     @Override

--- a/src/main/java/dev/cigarette/config/Config.java
+++ b/src/main/java/dev/cigarette/config/Config.java
@@ -1,7 +1,5 @@
 package dev.cigarette.config;
 
-import dev.cigarette.module.bedwars.*;
-import dev.cigarette.module.murdermystery.PlayerESP;
 import dev.cigarette.Cigarette;
 import dev.cigarette.agent.DevWidget;
 import dev.cigarette.gui.CategoryInstance;
@@ -13,13 +11,14 @@ import dev.cigarette.module.keybind.AddGlassBlock;
 import dev.cigarette.module.keybind.BreakBlock;
 import dev.cigarette.module.keybind.VClip;
 import dev.cigarette.module.murdermystery.GoldESP;
-import dev.cigarette.module.zombies.Aimbot;
+import dev.cigarette.module.murdermystery.PlayerESP;
 import dev.cigarette.module.render.ProjectileESP;
-import dev.cigarette.module.zombies.PowerupESP;
 import dev.cigarette.module.ui.GUI;
 import dev.cigarette.module.ui.ModuleList;
 import dev.cigarette.module.ui.Notifications;
 import dev.cigarette.module.ui.Watermark;
+import dev.cigarette.module.zombies.Aimbot;
+import dev.cigarette.module.zombies.PowerupESP;
 import dev.cigarette.module.zombies.ReviveAura;
 import dev.cigarette.module.zombies.ZombieESP;
 
@@ -39,12 +38,13 @@ public class Config {
     public final JumpReset COMBAT_JUMP_RESET = new JumpReset();
     public final PerfectHit COMBAT_PERFECT_HIT = new PerfectHit();
     public final PlayerESP MYSTERY_PLAYERESP = new PlayerESP();
+    public final Aimbot ZOMBIES_AIMBOT = new Aimbot();
 
     public Config() {
         this.keybinds.attach(new AddGlassBlock(), new BreakBlock(), new VClip());
         this.murderMystery.attach(MYSTERY_PLAYERESP, new GoldESP());
         this.bedwars.attach(new FireballESP(), new EntityESP(), new DefenseViewer(), new AutoTool(), new Bridger());
-        this.zombies.attach(new ZombieESP(), new Aimbot(), new ReviveAura(), new PowerupESP());
+        this.zombies.attach(new ZombieESP(), ZOMBIES_AIMBOT, new ReviveAura(), new PowerupESP());
         this.combat.attach(COMBAT_AUTOCLICKER, COMBAT_JUMP_RESET, COMBAT_PERFECT_HIT);
         this.render.attach(new dev.cigarette.module.render.PlayerESP(), new ProjectileESP());
         this.ui.attach(new GUI(), new Notifications(), new ModuleList(), RENDER_WATERMARK);

--- a/src/main/java/dev/cigarette/module/zombies/Aimbot.java
+++ b/src/main/java/dev/cigarette/module/zombies/Aimbot.java
@@ -15,6 +15,7 @@ import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.network.PendingUpdateManager;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.world.ClientWorld;
+import net.minecraft.entity.EntityPose;
 import net.minecraft.network.packet.c2s.play.PlayerInteractItemC2SPacket;
 import net.minecraft.registry.tag.BlockTags;
 import net.minecraft.text.Text;
@@ -73,7 +74,9 @@ public class Aimbot extends TickModule<ToggleWidget, Boolean> {
 
             if (!ZombiesAgent.isGun(player.getMainHandStack())) return;
 
-            Vec3d vector = bestTarget.getEndVec().normalize();
+            Vec3d start = player.getPos().add(0, player.getEyeHeight(EntityPose.STANDING), 0);
+            Vec3d end = bestTarget.getEndVec();
+            Vec3d vector = end.subtract(start).normalize();
 
             WeaponSelector.addCooldown(player.getInventory().getSelectedSlot());
 

--- a/src/main/java/dev/cigarette/module/zombies/Aimbot.java
+++ b/src/main/java/dev/cigarette/module/zombies/Aimbot.java
@@ -23,9 +23,6 @@ import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.Vec3d;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
-import java.util.*;
 
 public class Aimbot extends TickModule<ToggleWidget, Boolean> {
     protected static final String MODULE_NAME = "Aimbot";
@@ -67,7 +64,7 @@ public class Aimbot extends TickModule<ToggleWidget, Boolean> {
                 if (lookingAt.isIn(BlockTags.BUTTONS) || lookingAt.isOf(Blocks.CHEST)) return;
             }
 
-            ZombiesAgent.ZombieTarget bestTarget = getBestTarget(player);
+            ZombiesAgent.ZombieTarget bestTarget = ZombiesAgent.getBestTarget(player);
             if (bestTarget == null) return;
 
             if (autoWeaponSwitch.getRawState()) {

--- a/src/main/java/dev/cigarette/module/zombies/Aimbot.java
+++ b/src/main/java/dev/cigarette/module/zombies/Aimbot.java
@@ -35,13 +35,10 @@ public class Aimbot extends TickModule<ToggleWidget, Boolean> {
     private final ToggleWidget silentAim = new ToggleWidget(Text.literal("Silent Aim"), Text.literal("Doesn't snap your camera client-side.")).withDefaultState(true);
     private final ToggleWidget autoShoot = new ToggleWidget(Text.literal("Auto Shoot"), Text.literal("Automatically shoots zombies")).withDefaultState(true);
     private final ToggleWidget autoWeaponSwitch = new ToggleWidget(Text.literal("Auto Weapon Switch"), Text.literal("Automatically switch weapons")).withDefaultState(true);
-    private final ToggleWidget predictiveAim = new ToggleWidget(Text.literal("Predictive Aim"), Text.literal("Predict zombie movement for better accuracy")).withDefaultState(true);
-    private final SliderWidget predictionTicks = new SliderWidget(Text.literal("Prediction Ticks"), Text.literal("How many ticks ahead to predict zombie movement")).withBounds(1, 10, 20).withAccuracy(0);
+    public final ToggleWidget predictiveAim = new ToggleWidget(Text.literal("Predictive Aim"), Text.literal("Predict zombie movement for better accuracy")).withDefaultState(true);
+    public final SliderWidget predictionTicks = new SliderWidget(Text.literal("Prediction Ticks"), Text.literal("How many ticks ahead to predict zombie movement")).withBounds(1, 10, 20).withAccuracy(0);
 
     private KeyBinding rightClickKey = null;
-
-    private final Map<UUID, Vec3d> lastPositions = new HashMap<>();
-    private final Map<UUID, Vec3d> velocities = new HashMap<>();
 
     public Aimbot() {
         super(ToggleWidget::module, MODULE_ID, MODULE_NAME, MODULE_TOOLTIP);
@@ -51,101 +48,6 @@ public class Aimbot extends TickModule<ToggleWidget, Boolean> {
         autoWeaponSwitch.registerConfigKey("zombies.aimbot.autoWeaponSwitch");
         predictiveAim.registerConfigKey("zombies.aimbot.predictiveAim");
         predictionTicks.registerConfigKey("zombies.aimbot.predictionTicks");
-    }
-
-    @Nullable
-    private ZombiesAgent.ZombieTarget getBestTarget(ClientPlayerEntity player) {
-        HashSet<ZombiesAgent.ZombieTarget> zombies = ZombiesAgent.getZombies();
-        if (zombies.isEmpty()) {
-            return null;
-        }
-
-        ZombiesAgent.ZombieTarget bestTarget = null;
-        double minTimeToPlayer = Double.MAX_VALUE;
-
-        Vec3d playerPos = player.getPos();
-
-        for (ZombiesAgent.ZombieTarget zombie : zombies) {
-            Vec3d zombiePos = zombie.entity.getPos();
-            double distance = playerPos.distanceTo(zombiePos);
-
-            Vec3d velocity = velocities.getOrDefault(zombie.uuid, Vec3d.ZERO);
-            Vec3d playerToZombie = zombiePos.subtract(playerPos).normalize();
-            double speedTowardsPlayer = -velocity.dotProduct(playerToZombie) * 20;
-
-            if (speedTowardsPlayer <= 0.1) {
-                // Use distance as a fallback metric for stationary or retreating targets
-                if (bestTarget == null || distance < playerPos.distanceTo(bestTarget.entity.getPos())) {
-                    bestTarget = zombie;
-                }
-                continue;
-            }
-
-            double timeToPlayer = distance / speedTowardsPlayer;
-
-            if (timeToPlayer < minTimeToPlayer) {
-                minTimeToPlayer = timeToPlayer;
-                bestTarget = zombie;
-            }
-        }
-
-        return bestTarget;
-    }
-
-    private Vec3d calculatePredictedPosition(ZombiesAgent.ZombieTarget zombie, ClientPlayerEntity player) {
-        if (!predictiveAim.getRawState()) {
-            return zombie.getEndVec();
-        }
-
-        Vec3d currentPos = zombie.entity.getPos();
-        Vec3d playerPos = player.getEyePos();
-        Vec3d currentVelocity = velocities.getOrDefault(zombie.uuid, Vec3d.ZERO);
-        Vec3d pathDirection = getPathfindingDirection(zombie, currentPos, playerPos, currentVelocity);
-
-        if (pathDirection.lengthSquared() < 1.0E-7D) {
-            return zombie.getEndVec();
-        }
-
-        double distance = playerPos.distanceTo(currentPos);
-        double projectileSpeed = getProjectileSpeed();
-        double timeToTarget = (projectileSpeed > 0) ? distance / projectileSpeed : 0;
-
-        int maxPredictionTicks = predictionTicks.getRawState().intValue();
-        double maxPredictionTime = maxPredictionTicks / 20.0;
-        timeToTarget = Math.min(timeToTarget, maxPredictionTime);
-
-        Vec3d predictedBodyPos = currentPos.add(pathDirection.multiply(timeToTarget));
-
-        return predictedBodyPos.add(0, zombie.entity.getEyeHeight(zombie.entity.getPose()), 0);
-    }
-
-    private Vec3d getPathfindingDirection(ZombiesAgent.ZombieTarget zombie, Vec3d zombiePos, Vec3d playerPos, Vec3d currentVelocity) {
-        Vec3d directPath = playerPos.subtract(zombiePos).normalize();
-
-        if (currentVelocity.lengthSquared() > 1.0E-7D) {
-            Vec3d normalizedVelocity = currentVelocity.normalize();
-            double directness = normalizedVelocity.dotProduct(directPath);
-            directness = Math.max(0, Math.min(1, directness));
-
-            return directPath.multiply(1.0 - directness).add(normalizedVelocity.multiply(directness)).normalize().multiply(currentVelocity.length());
-        }
-
-        return directPath.multiply(estimateZombieSpeed(zombie) / 20.0);
-    }
-
-    private double estimateZombieSpeed(ZombiesAgent.ZombieTarget zombie) {
-        return switch (zombie.type) {
-            case ZOMBIE, SKELETON, CREEPER, WITCH -> 5.0; // ~0.25 B/t * 20 t/s
-            case BLAZE -> 8.0;
-            case WOLF -> 7.0;
-            case MAGMACUBE, SLIME -> 4.0;
-            case ENDERMITE, SILVERFISH -> 6.0;
-            default -> 5.0;
-        };
-    }
-
-    private double getProjectileSpeed() {
-        return 20.0;
     }
 
     @Override
@@ -198,40 +100,6 @@ public class Aimbot extends TickModule<ToggleWidget, Boolean> {
         cleanupTrackingData();
     }
 
-    private void updateAllZombieVelocities() {
-        HashSet<ZombiesAgent.ZombieTarget> zombies = ZombiesAgent.getZombies();
-        if (zombies.isEmpty()) {
-            velocities.clear();
-            return;
-        }
-
-        for (ZombiesAgent.ZombieTarget zombie : zombies) {
-            UUID zombieId = zombie.uuid;
-            Vec3d currentPos = zombie.entity.getPos();
-            Vec3d lastPos = lastPositions.get(zombieId);
-
-            if (lastPos != null) {
-                velocities.put(zombieId, currentPos.subtract(lastPos));
-            }
-            lastPositions.put(zombieId, currentPos);
-        }
-    }
-
-    private void cleanupTrackingData() {
-        Set<UUID> currentZombies = new HashSet<>();
-        for (ZombiesAgent.ZombieTarget zombie : ZombiesAgent.getZombies()) {
-            currentZombies.add(zombie.uuid);
-        }
-
-        lastPositions.keySet().retainAll(currentZombies);
-        velocities.keySet().retainAll(currentZombies);
-    }
-
-    @Override
-    protected void onDisabledTick(MinecraftClient client) {
-        lastPositions.clear();
-        velocities.clear();
-    }
 
     @Override
     public boolean inValidGame() {

--- a/src/main/java/dev/cigarette/module/zombies/Aimbot.java
+++ b/src/main/java/dev/cigarette/module/zombies/Aimbot.java
@@ -57,8 +57,6 @@ public class Aimbot extends TickModule<ToggleWidget, Boolean> {
             return;
         }
 
-        updateAllZombieVelocities();
-
         if (rightClickKey.isPressed() || autoShoot.getRawState()) {
             if (ZombiesAgent.getZombies().isEmpty()) return;
 
@@ -78,8 +76,7 @@ public class Aimbot extends TickModule<ToggleWidget, Boolean> {
 
             if (!ZombiesAgent.isGun(player.getMainHandStack())) return;
 
-            Vec3d predictedPos = calculatePredictedPosition(bestTarget, player);
-            Vec3d vector = predictedPos.subtract(player.getEyePos()).normalize();
+            Vec3d vector = bestTarget.getEndVec().normalize();
 
             WeaponSelector.addCooldown(player.getInventory().getSelectedSlot());
 
@@ -96,8 +93,6 @@ public class Aimbot extends TickModule<ToggleWidget, Boolean> {
                 player.networkHandler.sendPacket(new PlayerInteractItemC2SPacket(Hand.MAIN_HAND, seq, aimYaw, aimPitch));
             }
         }
-
-        cleanupTrackingData();
     }
 
 


### PR DESCRIPTION
Moves prediction logic back into the ZombiesAgent and performs raycasting checks on all zombies and their predicted locations before then determining the best target to shoot.

Closes issue #29 